### PR TITLE
Allow ENV vars in the routes too

### DIFF
--- a/scripts/config/lib/nginx_config_util.rb
+++ b/scripts/config/lib/nginx_config_util.rb
@@ -19,7 +19,7 @@ module NginxConfigUtil
 
   def self.parse_routes(json)
     routes = json.map do |route, target|
-      [to_regex(route), target]
+      [to_regex(route), interpolate(target, ENV)]
     end
 
     Hash[routes]


### PR DESCRIPTION
I think it would be interesting to allow ENV vars interpolation in `routes` node too.

I'm currently trying to map `/robots.txt` route to 2 different files: one for staging (disabling everything) and one for production. I would like to do something like:

```json
{
  "routes": {
    "/robots.txt": "robots.${STAGE}.txt",
    "/**": "index.html"
  }
}
```

And have two files (`robots.staging.txt` and `robots.production.txt`) in my public folder.